### PR TITLE
Add gofeed

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 
 * [feedparser](https://pypi.org/project/feedparser/) - (Python) Universal feed parser, handles RSS 0.9x and above, CDF, Atom 0.3 and above feeds.
 * [simplepie](http://simplepie.org/) - (PHP) SimplePie is a very fast and easy-to-use feed parser, written in PHP, that puts the 'simple' back into 'really simple syndication.
+* [gofeed](https://github.com/mmcdole/gofeed) - (Go) Gofeed a powerful and flexible library designed for parsing RSS, Atom, and JSON feeds across various formats and versions.
 
 # Contributing
 


### PR DESCRIPTION
## What is this RSS project?

[gofeed](https://github.com/mmcdole/gofeed) is a powerful and flexible library designed for parsing RSS, Atom, and JSON feeds across various formats and versions. It effectively manages non-standard elements and known extensions, and demonstrates resilience against common feed issues.

## What's the difference between this RSS project and similar ones?

Gofeed is the most widely used RSS library written in golang.

--

Anyone who agrees with this pull request could vote for it by adding a :+1: to it, and usually, the maintainer will merge it when votes reach **5**.
